### PR TITLE
Add missing dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,21 +39,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.openrewrite.gradle.tooling</groupId>
-            <artifactId>model</artifactId>
-            <version>2.7.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.gradle/gradle-tooling-api -->
-        <dependency>
-            <groupId>org.gradle</groupId>
-            <artifactId>gradle-tooling-api</artifactId>
-            <version>7.3-20210825160000+0000</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
             <version>2.35.1</version>
@@ -70,6 +55,12 @@
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java</artifactId>
+        </dependency>
+
+        <dependency> <!-- needed for the correct before spec operations -->
+            <groupId>org.openrewrite.gradle.tooling</groupId>
+            <artifactId>model</artifactId>
+            <version>2.8.0</version>
         </dependency>
 
         <dependency>
@@ -101,6 +92,19 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency> <!-- needed by OpenRewrite to hook into the groovy interpreter to parse gradle files -->
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <scope>test</scope>
+            <version>3.0.23</version>
+        </dependency>
+        <dependency> <!-- needed by OpenRewrite to utilize Gradle correctly-->
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-tooling-api</artifactId>
+            <version>7.3-20210825160000+0000</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.operaton.bpm</groupId>
             <artifactId>operaton-engine</artifactId>
@@ -122,7 +126,7 @@
             <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
                 <artifactId>rewrite-recipe-bom</artifactId>
-                <version>2.22.0</version>
+                <version>2.23.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/test/java/org/operaton/rewrite/MigrateDependenciesTest.java
+++ b/src/test/java/org/operaton/rewrite/MigrateDependenciesTest.java
@@ -118,20 +118,26 @@ public class MigrateDependenciesTest implements RewriteTest {
               plugins {
                 id('java')
               }
-
+              
+              repositories {
+                  mavenCentral()
+              }
+              
               dependencies {
                   implementation 'org.camunda.bpm:camunda-engine:7.22.0'
               }
               """,
             """
               plugins {
-                  id "java-library"
+                id('java')
               }
+              
               repositories {
                   mavenCentral()
-    
+              }
+              
               dependencies {
-                  implementation "org.operaton.bpm:operaton-engine:1.0.0-beta-1"
+                  implementation 'org.operaton.bpm:operaton-engine:1.0.0-beta-1'
               }
               """));
     }


### PR DESCRIPTION
Hi,
You made great progress, towards providing an easy migration path for your users  👍
I've found a fix for the Gradle migration tests:

- _org.openrewrite.gradle.tooling:model_ has to be recent
- same for _org.openrewrite.recipe:rewrite-recipe-bom_ 

Together, they provide the needed `withToolingApi` method and the other guiding errors.

I stick around and help wherever I can because we (OpenRewrite) have hidden issues here 😅. 
