### PR TITLE
feat(recipe): Add recipe to replace usage of Context#getExecutionContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <version.camunda>7.22.0</version.camunda>
     </properties>
 
     <dependencies>
@@ -69,6 +70,16 @@
             <groupId>org.openrewrite.recipe</groupId>
             <artifactId>rewrite-java-dependencies</artifactId>
         </dependency>
+
+        <!-- Camunda dependencies -->
+        <dependency>
+            <groupId>org.camunda.bpm</groupId>
+            <artifactId>camunda-engine</artifactId>
+            <version>${version.camunda}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.openrewrite</groupId>

--- a/src/main/resources/META-INF/rewrite/deprecations.yml
+++ b/src/main/resources/META-INF/rewrite/deprecations.yml
@@ -1,0 +1,10 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.operaton.rewrite.deprecation.ReplaceGetExecutionContext
+
+displayName: Replace usage of Context#getExecutionContext with Context#getBpmnExecutionContext
+description: Replace usage of `org.operaton.bpm.engine.impl.context.Context#getExecutionContext` with `org.operaton.bpm.engine.impl.context.Context#getBpmnExecutionContext`.
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: 'org.camunda.bpm.engine.impl.context.Context getExecutionContext()'
+      newMethodName: 'getBpmnExecutionContext'

--- a/src/test/java/org/operaton/rewrite/ResolveDeprecationsTest.java
+++ b/src/test/java/org/operaton/rewrite/ResolveDeprecationsTest.java
@@ -1,0 +1,45 @@
+package org.operaton.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ResolveDeprecationsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.operaton.rewrite.deprecation.ReplaceGetExecutionContext");
+    }
+
+    @Test
+    void resolve_Context_getExecutionContext() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.operaton.rewrite.deprecation.ReplaceGetExecutionContext"),
+          java(
+            """
+              package foo;
+              
+              import org.camunda.bpm.engine.impl.context.Context;
+              
+              class Test {
+                  void test() {
+                      var ctx = Context.getExecutionContext();
+                  }
+              }
+              """,
+              """
+              package foo;
+              
+              import org.camunda.bpm.engine.impl.context.Context;
+              
+              class Test {
+                  void test() {
+                      var ctx = Context.getBpmnExecutionContext();
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
Method `Context#getExecutionContext()` is deprecated and should be replaced by `Context#getBpmnExecutionContext()`

Adds `deprecations.yml`.

Usage of deprecated methods should be refactored before migrating to Operaton. This allows to remove the deprecated methods from the Operaton code base.

closes #38