### PR TITLE
Fix README documentation supposed plugin version 6.0.9 -> 7.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use these recipes in your Maven-based Spring Boot project, add the following 
         <plugin>
             <groupId>org.openrewrite.maven</groupId>
             <artifactId>rewrite-maven-plugin</artifactId>
-            <version>6.9.0</version>
+            <version>7.0.4</version>
             <configuration>
                 <activeRecipes>
                     <recipe>org.operaton.rewrite.spring.MigrateSpringBootApplication</recipe>
@@ -53,7 +53,7 @@ For Gradle projects, add the following to your `build.gradle`:
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite") version("6.9.0")
+    id("org.openrewrite.rewrite") version("7.0.4")
 }
 
 repositories {


### PR DESCRIPTION
Fix README documentation, NoClassDefFoundError from openrewrite incversion incompatibility

fix(rewrite): Fix README supposed plugin version

- changed supposed rewrite plugin version from 6.0.9 to 7.0.4

closes #121