### PR TITLE
docs(README): use correct gradle and maven plugin versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For Gradle projects, add the following to your `build.gradle`:
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite") version("7.0.4")
+    id("org.openrewrite.rewrite") version("7.14.1")
 }
 
 repositories {
@@ -103,7 +103,7 @@ You can also run the MigrateSpringBootApplication recipe without modifying your 
 ### Maven
 
 ```bash
-mvn org.openrewrite.maven:rewrite-maven-plugin:7.0.4:run \
+mvn org.openrewrite.maven:rewrite-maven-plugin:6.17.0:run \
   -Drewrite.recipeArtifactCoordinates=org.operaton:migrate-camunda-recipe:1.0.0-beta-2 \
   -Drewrite.activeRecipes=org.operaton.rewrite.spring.MigrateSpringBootApplication
 ```


### PR DESCRIPTION
### Use Correct Maven and Gradle plugin Versions

Documenting the current Maven and Gradle plugin versions has been a source of great confusion over the last weeks. This pr attempts to use the latest version of the plugins in the whole README. Should we switch to a `latest`, or `latest.release` style rolling version or is it important to stick to a known release?

* Gradle Plugin
  * https://mvnrepository.com/artifact/org.openrewrite.maven/rewrite-maven-plugin
  * https://docs.openrewrite.org/reference/gradle-plugin-configuration
*  Maven Plugin
   * https://mvnrepository.com/artifact/org.openrewrite.maven/rewrite-maven-plugin
   * https://docs.openrewrite.org/reference/rewrite-maven-plugin