### PR TITLE
docs(README): update Gradle guide with an init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,36 @@ mvn org.openrewrite.maven:rewrite-maven-plugin:6.17.0:run \
 
 ### Gradle
 
-[Create a `init.gradle` file](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build).
+[Create a init.gradle file](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build). It does not need to be in the project directory itself (although it will make it easier for this guide). Copy the below init script to your file:
+
+```groovy
+initscript {
+  repositories {
+    maven { url "https://plugins.gradle.org/m2" }
+  }
+  dependencies {
+    classpath("org.openrewrite:plugin:7.14.1")
+  }
+}
+
+rootProject {
+  plugins.apply(org.openrewrite.gradle.RewritePlugin)
+  dependencies {
+    rewrite("org.operaton:migrate-camunda-recipe:1.0.0-beta-2")
+  }
+
+  afterEvaluate {
+    if (repositories.isEmpty()) {
+      repositories {
+        mavenCentral()
+      }
+    }
+  }
+}
+```
 
 ```bash
-./gradlew rewriteRun \
-  --rewrite.recipeArtifactCoordinates=org.operaton:migrate-camunda-recipe:1.0.0-beta-2 \
-  --rewrite.activeRecipes=org.operaton.rewrite.spring.MigrateSpringBootApplication
+./gradlew --init-script init.gradle rewriteRun -Drewrite.activeRecipe=org.operaton.rewrite.spring.MigrateSpringBootApplication
 ```
 
 This approach allows you to apply the migration without adding the plugin to your build configuration.


### PR DESCRIPTION
### Update Gradle guide with an init script for recipe usage without modifying the build

Update the Instructions for Gradle without modifying the build.

Tested against https://github.com/cachescrubber/migrate-from-camunda-gradle-demo