### PR TITLE
Add `static` to `ProcessEngineExtension`

### DIFF
--- a/src/main/java/org/operaton/rewrite/DummyForJavadoc.java
+++ b/src/main/java/org/operaton/rewrite/DummyForJavadoc.java
@@ -1,4 +1,0 @@
-package org.operaton.rewrite;
-
-public class DummyForJavadoc {
-}

--- a/src/main/java/org/operaton/rewrite/MakeProcessEngineStatic.java
+++ b/src/main/java/org/operaton/rewrite/MakeProcessEngineStatic.java
@@ -37,7 +37,7 @@ public class MakeProcessEngineStatic extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaVisitor<ExecutionContext>() {
+        return new JavaVisitor<>() {
             final TypeMatcher processEngineExtensionType = new TypeMatcher("org.operaton.bpm.engine.ProcessEngineExtension");
             
             @Override
@@ -47,8 +47,8 @@ public class MakeProcessEngineStatic extends Recipe {
                     return multiVariable;
                 }
 
-                // skip if not private or already static
-                if (!multiVariable.hasModifier(J.Modifier.Type.Private) || multiVariable.hasModifier(J.Modifier.Type.Static)) {
+                // skip if already static
+                if (multiVariable.hasModifier(J.Modifier.Type.Static)) {
                     return multiVariable;
                 }
 

--- a/src/main/java/org/operaton/rewrite/MakeProcessEngineStatic.java
+++ b/src/main/java/org/operaton/rewrite/MakeProcessEngineStatic.java
@@ -1,0 +1,62 @@
+package org.operaton.rewrite;
+
+import org.checkerframework.errorprone.dataflow.expression.FieldAccess;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.analysis.trait.variable.VariableUtil;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.TypeMatcher;
+import org.openrewrite.java.trait.VariableAccess;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.J.VariableDeclarations;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.marker.Markers;
+
+import java.lang.ProcessBuilder.Redirect.Type;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+
+public class MakeProcessEngineStatic extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Make ProcessEngineExtension field static and update references";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrates ProcessEngineExtension field to static and updates references from 'this.extension' to 'ClassName.extension'.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+            final TypeMatcher processEngineExtensionType = new TypeMatcher("org.operaton.bpm.engine.ProcessEngineExtension");
+            
+            @Override
+            public VariableDeclarations visitVariableDeclarations(VariableDeclarations multiVariable, ExecutionContext p) {
+                // skip if not correct type
+                if (!processEngineExtensionType.matches(multiVariable.getType())) {
+                    return multiVariable;
+                }
+
+                // skip if not private or already static
+                if (!multiVariable.hasModifier(J.Modifier.Type.Private) || multiVariable.hasModifier(J.Modifier.Type.Static)) {
+                    return multiVariable;
+                }
+
+                // add static to field
+                return multiVariable.withModifiers(ListUtils.concat(
+                    multiVariable.getModifiers(), 
+                    new J.Modifier(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, null, J.Modifier.Type.Static, emptyList())));
+            }
+        };
+    }
+}

--- a/src/test/java/org/operaton/rewrite/MakeProcessEngineStaticTest.java
+++ b/src/test/java/org/operaton/rewrite/MakeProcessEngineStaticTest.java
@@ -1,0 +1,132 @@
+package org.operaton.rewrite;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import static org.openrewrite.java.Assertions.java;
+
+class MakeProcessEngineStaticTest implements RewriteTest{
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(
+            JavaParser.fromJavaVersion()
+                .classpath("operaton-engine")
+                .dependsOn(
+                //language=java
+                """
+                package org.operaton.bpm.engine;
+
+                public class ProcessEngineExtension {
+                    public static Builder builder() { return new Builder(); }
+                    public static class Builder {
+                        public Builder configurationResource(String resource) { return this; }
+                        public ProcessEngineExtension build() { return new ProcessEngineExtension(); }
+                    }
+                }
+                """
+                )
+            )
+        .recipe(new org.operaton.rewrite.MakeProcessEngineStatic());
+    }
+
+    @Test
+    @DocumentExample
+    void updateThisToClassName() {
+        rewriteRun(
+            java(
+            """
+            import org.operaton.bpm.engine.ProcessEngineExtension;
+
+            public class Example {
+                private ProcessEngineExtension extension = ProcessEngineExtension.builder()
+                    .configurationResource("operaton.local.cfg.xml")
+                    .build();
+
+                public void someMethod() {
+                    this.extension = null;
+                    this.extension.toString();
+                }
+            }
+            """,
+            """
+            import org.operaton.bpm.engine.ProcessEngineExtension;
+
+            public class Example {
+                private static ProcessEngineExtension extension = ProcessEngineExtension.builder()
+                    .configurationResource("operaton.local.cfg.xml")
+                    .build();
+
+                public void someMethod() {
+                    this.extension = null;
+                    this.extension.toString();
+                }
+            }
+            """
+            )
+        );
+    }
+
+    @Nested
+    class DoNothing {
+        @Test
+        void alreadyStatic() {
+            rewriteRun(
+              java(
+                //language=java
+                """
+                import org.operaton.bpm.engine.ProcessEngineExtension;
+                
+                public class Example {
+                    private static ProcessEngineExtension extension = ProcessEngineExtension.builder()
+                        .configurationResource("operaton.local.cfg.xml")
+                        .build();
+                }
+                """
+              )
+            );
+        }
+
+        @Test
+        void notPrivate() {
+            rewriteRun(
+              java(
+                //language=java
+                """
+                import org.operaton.bpm.engine.ProcessEngineExtension;
+
+                public class Example {
+                    static ProcessEngineExtension extension = ProcessEngineExtension.builder()
+                        .configurationResource("operaton.local.cfg.xml")
+                        .build();
+                }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void differentClass() {
+            rewriteRun(
+                java(
+                    """
+                    public class OtherClass { }        
+                    """
+                ),
+                java(
+                    //language=java
+                    """
+                    import org.operaton.bpm.engine.ProcessEngineExtension;
+    
+                    public class Example {
+                        private OtherClass extension = new OtherClass();
+                    }
+                    """
+                )
+            );
+        }
+    }
+}

--- a/src/test/java/org/operaton/rewrite/MakeProcessEngineStaticTest.java
+++ b/src/test/java/org/operaton/rewrite/MakeProcessEngineStaticTest.java
@@ -45,11 +45,6 @@ class MakeProcessEngineStaticTest implements RewriteTest{
                 private ProcessEngineExtension extension = ProcessEngineExtension.builder()
                     .configurationResource("operaton.local.cfg.xml")
                     .build();
-
-                public void someMethod() {
-                    this.extension = null;
-                    this.extension.toString();
-                }
             }
             """,
             """
@@ -59,11 +54,6 @@ class MakeProcessEngineStaticTest implements RewriteTest{
                 private static ProcessEngineExtension extension = ProcessEngineExtension.builder()
                     .configurationResource("operaton.local.cfg.xml")
                     .build();
-
-                public void someMethod() {
-                    this.extension = null;
-                    this.extension.toString();
-                }
             }
             """
             )
@@ -91,29 +81,11 @@ class MakeProcessEngineStaticTest implements RewriteTest{
         }
 
         @Test
-        void notPrivate() {
-            rewriteRun(
-              java(
-                //language=java
-                """
-                import org.operaton.bpm.engine.ProcessEngineExtension;
-
-                public class Example {
-                    static ProcessEngineExtension extension = ProcessEngineExtension.builder()
-                        .configurationResource("operaton.local.cfg.xml")
-                        .build();
-                }
-                  """
-              )
-            );
-        }
-
-        @Test
         void differentClass() {
             rewriteRun(
                 java(
                     """
-                    public class OtherClass { }        
+                    public class OtherClass { }
                     """
                 ),
                 java(


### PR DESCRIPTION
This pull request introduces a new recipe to automate the migration of `ProcessEngineExtension` fields to static and includes comprehensive tests for this functionality.