### PR TITLE
Move CollectionUtils and Mock classes

### DIFF
--- a/src/main/resources/META-INF/rewrite/change-type.yml
+++ b/src/main/resources/META-INF/rewrite/change-type.yml
@@ -413,3 +413,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.camunda.bpm.spring.boot.starter.webapp.CamundaBpmWebappAutoConfiguration
       newFullyQualifiedTypeName: org.operaton.bpm.spring.boot.starter.webapp.OperatonBpmWebappAutoConfiguration
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.camunda.bpm.engine.impl.util.CollectionUtil
+      newFullyQualifiedTypeName: org.operaton.commons.utils.CollectionUtil

--- a/src/main/resources/META-INF/rewrite/moved-test-classes.yml
+++ b/src/main/resources/META-INF/rewrite/moved-test-classes.yml
@@ -1,0 +1,41 @@
+#
+# Copyright 2025 the Operaton contributors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.operaton.rewrite.MoveTestClasses
+displayName: Handle Operaton test classes relocation
+description: Move various classes for test support in new packages and a new artifact.
+recipeList:
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.operaton.bpm
+      artifactId: operaton-engine
+      version: 1.0.+
+      scope: test
+      classifier: junit4
+      onlyIfUsing: org.junit.Test
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.operaton.bpm
+      artifactId: operaton-engine
+      version: 1.0.+
+      scope: test
+      classifier: junit5
+      onlyIfUsing: org.junit.jupiter.Test
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.operaton.bpm.engine.test.mock.Mocks
+      newFullyQualifiedTypeName: org.operaton.bpm.engine.impl.mock.Mocks
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.operaton.bpm.engine.test.mock.MockExpressionManager;
+      newFullyQualifiedTypeName: org.operaton.bpm.engine.impl.mock.MockExpressionManager


### PR DESCRIPTION
**Test class relocation and dependency management:**

Added a new rewrite recipe file `moved-test-classes.yml` to automate the relocation of test support classes to new packages and artifacts, including adding test dependencies for both JUnit 4 and JUnit 5 (`operaton-engine` with appropriate classifiers) and updating type mappings for mock classes (`Mocks` and `MockExpressionManager`).

Should fix https://github.com/operaton/migrate-from-camunda-recipe/issues/164.

**Utility class migration:**

Updated the type mapping in `change-type.yml` to migrate references from `org.camunda.bpm.engine.impl.util.CollectionUtil` to `org.operaton.commons.utils.CollectionUtil`.

Should fix https://github.com/operaton/migrate-from-camunda-recipe/issues/165.